### PR TITLE
Stop parsing arguments as soon as something that is obviously not a flag is hit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,7 +594,8 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
         let cur = args[i].clone();
         let curlen = cur.len();
         if !is_arg(cur.as_slice()) {
-            free.push(cur);
+            while i < l { free.push(args[i].clone()); i += 1; }
+            break;
         } else if cur == "--" {
             let mut j = i + 1;
             while j < l { free.push(args[j].clone()); j += 1; }
@@ -1355,11 +1356,8 @@ mod tests {
     #[test]
     fn test_combined() {
         let args =
-            vec!("prog".to_string(),
-                 "free1".to_string(),
-                 "-s".to_string(),
+            vec!("-s".to_string(),
                  "20".to_string(),
-                 "free2".to_string(),
                  "--flag".to_string(),
                  "--long=30".to_string(),
                  "-f".to_string(),
@@ -1382,10 +1380,7 @@ mod tests {
         let rs = getopts(args.as_slice(), opts.as_slice());
         match rs {
           Ok(ref m) => {
-            assert!(m.free[0] == "prog");
-            assert!(m.free[1] == "free1");
             assert_eq!(m.opt_str("s").unwrap(), "20");
-            assert!(m.free[2] == "free2");
             assert!((m.opt_present("flag")));
             assert_eq!(m.opt_str("long").unwrap(), "30");
             assert!((m.opt_present("f")));
@@ -1396,6 +1391,31 @@ mod tests {
             assert!(pair[0] == "-A B");
             assert!(pair[1] == "-60 70");
             assert!((!m.opt_present("notpresent")));
+          }
+          _ => panic!()
+        }
+    }
+
+    #[test]
+    fn test_mixed() {
+        let args =
+            vec!("-a".to_string(),
+                 "b".to_string(),
+                 "-c".to_string(),
+                 "d".to_string());
+        let opts =
+            vec!(optflag("a", "", ""),
+              optopt("c", "", "", ""));
+        let rs = getopts(args.as_slice(), opts.as_slice());
+        match rs {
+          Ok(ref m) => {
+            println!("{}", m.opt_present("c"));
+            assert!(m.opt_present("a"));
+            assert!(!m.opt_present("c"));
+            assert_eq!(m.free.len(), 3);
+            assert_eq!(m.free[0], "b");
+            assert_eq!(m.free[1], "-c");
+            assert_eq!(m.free[2], "d");
           }
           _ => panic!()
         }


### PR DESCRIPTION
eAt the moment, getopts parses a command like (NB: ignoring the program name of
the comand being run) "a -b c" as having opts={"-b":"c"} and free=["a"]. If
instead one does "-- a -b c" one gets opts={} and free=["a", "-b", -"]. However,
the former behaviour doesn't match what Unix's getopts does which confused me.

For example a Unix command like:

    $ find . | xargs ls -l

prints out the long version of every file that find prints, even without
explicitly using "--" with xargs. While this implicitness may or may not be a
good idea, subverting this expectation confuses old farts like me.

This patch therefore makes the getopts crate parse a command line "a -b c" is
parsed as having opts={} and free=["a", "-b", "c"].