### PR TITLE
Add ability to set different parsing styles for getopts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ impl Options {
 }
 
 /// What parsing style to use when parsing arguments
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ParsingStyle {
     /// Flags and "free" arguments can be freely inter-mixed.
     FloatingFrees,
@@ -382,7 +382,6 @@ pub enum ParsingStyle {
     /// considering any remaining arguments as flags.
     StopAtFirstFree
 }
-impl Copy for ParsingStyle {}
 
 /// Name of an option. Either a string or a single char.
 #[derive(Clone, PartialEq, Eq)]


### PR DESCRIPTION
The default preserves the previous behaviour, so most users will not notice
any difference. However, if one sets the parsing stye to StopAtFirstFree,
one gets xarg-ish parsing, which is necessary for tools which have
sub-commands passed to them.