### PR TITLE
Bump log dependency to 0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ getopts-like option parsing.
 """
 
 [dependencies]
-log = "0.2"
+log = "0.3"


### PR DESCRIPTION
Changes the dependency on the log crate to 0.3 from 0.2. Everything still builds just fine.