### PR TITLE
Make usage string match program in docs example.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! }
 //!
 //! fn print_usage(program: &str, opts: Options) {
-//!     let brief = format!("Usage: {} [options]", program);
+//!     let brief = format!("Usage: {} FILE [options]", program);
 //!     print!("{}", opts.usage(&brief));
 //! }
 //!


### PR DESCRIPTION
The example program has a required input that is not reflected in the usage string.