### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -713,17 +713,7 @@ pub enum Fail {
     UnexpectedArgument(String),
 }
 
-impl Error for Fail {
-    fn description(&self) -> &str {
-        match *self {
-            ArgumentMissing(_) => "missing argument",
-            UnrecognizedOption(_) => "unrecognized option",
-            OptionMissing(_) => "missing option",
-            OptionDuplicated(_) => "duplicated option",
-            UnexpectedArgument(_) => "unexpected argument",
-        }
-    }
-}
+impl Error for Fail {}
 
 /// The result of parsing a command line with a set of options.
 pub type Result = result::Result<Matches, Fail>;


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `Error::description`

Related PR: https://github.com/rust-lang/rust/pull/66919