### PR TITLE
Add a note about getopts constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Add this to your `Cargo.toml`:
 [dependencies]
 getopts = "0.2"
 ```
+
+## Contributing
+
+The `getopts` library is used by `rustc`, so we have to be careful about not changing its behavior.


### PR DESCRIPTION
Just thinking back to #84, we need to be careful not to change the way arguments are parsed or we could change the behaviour of `rustc`.

At this point, maybe it’s worth just bumping `getopts` to `1.0`?