### PR TITLE
Add support for detecting args after double-dash

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -207,12 +207,24 @@ fn test_optflag_missing() {
 }
 
 #[test]
-fn test_opt_end() {
+fn test_free_trailing_missing() {
+    let args = vec![] as Vec<String>;
+    match Options::new().parse(&args) {
+        Ok(ref m) => {
+            assert_eq!(m.free_trailing_start(), None);
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_free_trailing() {
     let args = vec!["--".to_owned(), "-t".to_owned()];
     match Options::new().optflag("t", "test", "testing").parse(&args) {
         Ok(ref m) => {
             assert!(!m.opt_present("test"));
             assert!(!m.opt_present("t"));
+            assert_eq!(m.free_trailing_start(), Some(0));
             assert_eq!(m.free.len(), 1);
             assert_eq!(m.free[0], "-t");
         }
@@ -221,13 +233,26 @@ fn test_opt_end() {
 }
 
 #[test]
-fn test_opt_only_end() {
+fn test_free_trailing_only() {
     let args = vec!["--".to_owned()];
     match Options::new().optflag("t", "test", "testing").parse(&args) {
         Ok(ref m) => {
             assert!(!m.opt_present("test"));
             assert!(!m.opt_present("t"));
+            assert_eq!(m.free_trailing_start(), None);
             assert_eq!(m.free.len(), 0);
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_free_trailing_args() {
+    let args = vec!["pre".to_owned(), "--".to_owned(), "post".to_owned() ];
+    match Options::new().parse(&args) {
+        Ok(ref m) => {
+            assert_eq!(m.free_trailing_start(), Some(1));
+            assert_eq!(m.free.len(), 2);
         }
         _ => panic!(),
     }


### PR DESCRIPTION
The crate provides support for detecting and ignoring double-dash ("--")
argument passed from command line, but it does not provide any
information about its presence or position to user.

For applications that may want to pass arguments after double-dash to
child process is such indication critical.

Add optional field `args_end` into Matches structure storing position of
first argument after double-dash (if there is any) and method to provide
user access to the data.

When checking for double-dash positin, it is important to make sure that
there actually are some arguments after it. Otherwise the position would
point to non-existent index in `free` list and would require additional
unnecessary checks on user side.