### PR TITLE
Fix compiler warning in documentation example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!     opts.optflag("h", "help", "print this help menu");
 //!     let matches = match opts.parse(&args[1..]) {
 //!         Ok(m) => { m }
-//!         Err(f) => { panic!(f.to_string()) }
+//!         Err(f) => { panic!("{}", f.to_string()) }
 //!     };
 //!     if matches.opt_present("h") {
 //!         print_usage(&program, opts);


### PR DESCRIPTION
Add format string to panic!() when handling Options parse() result
to avoid compiler warning.