### PR TITLE
Update version number in html_root_url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getopts/0.2.20"
+    html_root_url = "https://docs.rs/getopts/0.2.21"
 )]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]


### PR DESCRIPTION
It looks like this was missed in be919b8323f57ba238ea9cd6e68190029809e278.