### PR TITLE
Document and start testing the MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,17 @@ jobs:
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: cargo test
       - run: cargo doc
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: |
+          msrv="$(cargo metadata --format-version=1 |
+            jq -r '.packages[] | select(.name == "getopts").rust_version'
+          )"
+          rustup update "$msrv" && rustup default "$msrv"
+      - run: |
+          cargo update -p unicode-width --precise 0.1.8
+          cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ description = """
 getopts-like option parsing.
 """
 categories = ["command-line-interface"]
+edition = "2018"
+rust-version = "1.49"
 
 [dependencies]
 unicode-width = "0.1.5"


### PR DESCRIPTION
Check the MSRV in CI and document it as an extremely low 1.49 (the oldest version I could test with locally, it's probably actually older than that). This is intended so we can do one final release with `rust-version` documented, then increase it in a follow up to 1.66 which will be needed for `unicode-width` 0.2.