### PR TITLE
Update the MSRV to 1.66 and edition to 2021

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,4 @@ jobs:
             jq -r '.packages[] | select(.name == "getopts").rust_version'
           )"
           rustup update "$msrv" && rustup default "$msrv"
-      - run: |
-          cargo update -p unicode-width --precise 0.1.8
-          cargo check
+      - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "getopts"
 version = "0.2.21"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-lang/getopts"
 documentation = "https://doc.rust-lang.org/getopts"
 homepage = "https://github.com/rust-lang/getopts"
@@ -11,8 +10,8 @@ description = """
 getopts-like option parsing.
 """
 categories = ["command-line-interface"]
-edition = "2018"
-rust-version = "1.49"
+edition = "2021"
+rust-version = "1.66"
 
 [dependencies]
 unicode-width = "0.1.5"
@@ -23,4 +22,4 @@ core = { version = "1.0", package = "rustc-std-workspace-core", optional = true 
 log = "0.4"
 
 [features]
-rustc-dep-of-std = ['unicode-width/rustc-dep-of-std', 'std', 'core']
+rustc-dep-of-std = ["unicode-width/rustc-dep-of-std", "std", "core"]


### PR DESCRIPTION
Match what is required by `unicode-width` version 0.2.