### PR TITLE
Fix smoke test harness arguments

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -4,5 +4,7 @@ use std::env;
 
 #[test]
 fn main() {
-    getopts::Options::new().parse(env::args()).unwrap();
+    let program = env::args().next().unwrap();
+
+    getopts::Options::new().parse([program]).unwrap();
 }


### PR DESCRIPTION
Fixes #113.

The smoke test now parses only its controlled program argument instead of the full test harness argv, so libtest flags such as `--test-threads` do not make the test fail.

Checked with:
- `cargo test --test smoke -- --test-threads 1 -q`
- `cargo test`
- `cargo test --no-default-features`
- `cargo fmt --check`